### PR TITLE
improves function name generation by normalizing namespace and function name to single url compatible string

### DIFF
--- a/boot/build.boot
+++ b/boot/build.boot
@@ -1,10 +1,13 @@
-(set-env! :resource-paths #{"src"}
+(set-env! :source-paths #{"test"}
+          :resource-paths #{"src"}
           :dependencies '[[org.clojure/clojure "1.8.0"]
                           [boot/core "2.7.2" :scope "provided"]
                           [cheshire "5.8.0"]
-                          [adzerk/bootlaces "0.1.13" :scope "test"]])
+                          [adzerk/bootlaces "0.1.13" :scope "test"]
+                          [adzerk/boot-test "1.2.0" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
+(require '[adzerk.boot-test :refer :all])
 
 (def +version+ "0.0.1-SNAPSHOT")
 

--- a/boot/src/boot_hedge/core.clj
+++ b/boot/src/boot_hedge/core.clj
@@ -38,6 +38,16 @@
         (recur)
         func-ns))))
 
+(defn dashed-alphanumeric [s]
+  (str/replace s #"[^A-Za-z0-9\-]" "_"))
+
+(defn generate-cloud-name [handler]
+  ; hedge-test.core/hello => hedge-test_core__hello
+  (str 
+    (dashed-alphanumeric (namespace handler))
+    "__"
+    (dashed-alphanumeric (name handler))))
+
 (defn generate-source [fs {:keys [handler]}]
   (let [handler-ns (symbol (namespace handler))
         handler-func (symbol (name handler))
@@ -52,7 +62,7 @@
     (clojure.pprint/pprint (slurp ff))
     {:fs (-> fs (c/add-source tgt) c/commit!)
      :func func-ns
-     :cloud-name  (last (str/split (name handler-ns) #"\."))}))
+     :cloud-name (generate-cloud-name handler)}))
 
 (defn generate-cljs-edn [dir fns]
   (doto (clojure.java.io/file dir "index.cljs.edn")

--- a/boot/test/boot_hedge/core_test.clj
+++ b/boot/test/boot_hedge/core_test.clj
@@ -1,0 +1,9 @@
+(ns boot-hedge.core-test
+    (:require [clojure.test :refer :all]
+              [boot-hedge.core :refer :all]))
+  
+(deftest function-json-test
+  (testing "symbol representing the function is normalized to URL compatible form"
+    (testing "allows changing path"      
+      (is (= (generate-cloud-name (symbol "my-app.core" "fn-name"))
+             "my-app_core__fn-name")))))


### PR DESCRIPTION
In practice this changes `hedge-test.core/hello` to `hedge-test_core__hello` which should be unique enough.