### PR TITLE
 removed documentation about a task that was removed from 0.0.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,7 @@ in the future.
 
     # Deploy compiled artifacts from target directory (index.js and function.json)
     boot deploy-azure-from-directory -a functionapp -r resourcegroup -d <directory>
+
+    # Get more help of task, i.e. commandline options
+    boot <task-name> -h
+

--- a/README.md
+++ b/README.md
@@ -188,10 +188,7 @@ in the future.
     # Deploy to Azure and Persist the compiled artifacts in **target/** directory (index.js and function.json)
     boot deploy-azure -a functionapp -r resourcegroup target
 
-    # Persist the compiled output to target/ without deploy
-    boot deploy-to-target
-
-    # Persist the compiled output to <directory>
+    # Persist the compiled output. Given no options, defaults to Optimizations=simple and directory=target
     boot deploy-to-directory -O <optimization level> -f <function name> -d <directory>
 
     # Deploy compiled artifacts from target directory (index.js and function.json)


### PR DESCRIPTION
also clarified documentation for **deploy-to-directory** task
