### PR TITLE
New change

### DIFF
--- a/boot/src/boot_hedge/core.clj
+++ b/boot/src/boot_hedge/core.clj
@@ -1,0 +1,15 @@
+(ns boot-hedge.core
+  (:require [boot.core          :as c]))
+
+(def SUPPORTED_CLOUDS [:aws :azure])
+
+(c/deftask hedge-help "Placeholder task, please run init! to import Hedge tasks" []
+  (println "TODO: add some message here"))
+
+(defn init! [& {:keys [clouds]
+                :or {clouds SUPPORTED_CLOUDS}}]
+  (ns-unmap 'boot-hedge.core 'hedge-help)
+  (doseq [cloud clouds]
+    (case cloud
+      :aws (require '[boot-hedge.aws.core :as aws])
+      :azure (require '[boot-hedge.azure.core :as azure]))))


### PR DESCRIPTION
 * Added boot-hedge.core/init!
   * boot-hedge.core automatically imports a placeholder task which gives a hint to
     use init! for task import. Placeholder task is automatically removed when init! is called
 * init! imports tasks
 * note: importing tasks with (require '[boot-hedge.<cloud>.core :refer :all]) still work
   but usage of init! is recommended

Basic task import with build.boot:

```clojure
(require  '[boot-hedge.core :as hedge])
(hedge/init!) ; import all supported cloud tasks
;(hedge/init! :clouds [:aws]) ; import aws tasks
;(hedge/init! :clouds [:azure]) ; import azure tasks
;(hedge/init! :clouds [:azure :aws]) ; import azure and aws tasks
```