### PR TITLE
azure timer initial work

### DIFF
--- a/boot/src/boot_hedge/azure/function_app.clj
+++ b/boot/src/boot_hedge/azure/function_app.clj
@@ -4,7 +4,8 @@
    [boot.util          :as util]
    [clojure.string :as str]
    [boot.filesystem :as fs]
-   [boot-hedge.common.core :refer [serialize-json]]))
+   [boot-hedge.core :refer [SUPPORTED_HANDLERS AZURE_FUNCTION]]
+   [boot-hedge.common.core :refer [serialize-json one-handler-config]]))
 
 (defn read-conf [fileset]
   (->> fileset
@@ -42,17 +43,20 @@
     "__"
     (dashed-alphanumeric (name handler))))
 
-(defn generate-source [fs {:keys [handler]}]
-  (let [handler-ns (symbol (namespace handler))
+(defn generate-source [fs {:keys [function type]}]
+  (let [handler (-> function :handler)
+        handler-ns (symbol (namespace handler))
         handler-func (symbol (name handler))
         func-ns (hedge-ns fs handler-ns)
         tgt (c/tmp-dir!)
-        ff (clojure.java.io/file tgt (ns-file func-ns))]
+        ff (clojure.java.io/file tgt (ns-file func-ns))
+        azure-function (get AZURE_FUNCTION type)]
+
     (doto ff
       clojure.java.io/make-parents
-      (spit `(~'ns ~func-ns (:require [hedge.azure.function-app :refer-macros [~'azure-function]]
+      (spit `(~'ns ~func-ns (:require [hedge.azure.function-app :refer-macros [~azure-function]]
                                      [~handler-ns :as ~'handler])))
-      (spit `(~'azure-function ~(symbol (str 'handler "/" handler-func))) :append true))
+      (spit `(~azure-function ~(symbol (str 'handler "/" handler-func))) :append true))
     (clojure.pprint/pprint (slurp ff))
     {:fs (-> fs (c/add-source tgt) c/commit!)
      :func func-ns
@@ -64,7 +68,9 @@
     (spit  {:require [fns]}))
   dir)
 
-(defn function-json [path authorization]
+(defn function-json-for-api 
+  "function.json constructor for function of type api (http in / http out)"
+  [path authorization]
   {:bindings
    [{:authLevel (name authorization),
      :type "httpTrigger",
@@ -74,12 +80,33 @@
     {:type "http", :direction "out", :name "$return"}],
    :disabled false})
 
-(defn generate-function-json [{:keys [fs cloud-name]} path {:keys [authorization] :or {authorization :anonymous}}]
+(defn function-json-for-timer
+  "function.json constructor for function of type timer (timer trigger in). Generates the seconds field as zero."
+  [cron]
+   {:bindings 
+    [{:name "timer",
+      :type "timerTrigger",
+      :direction "in",
+      :schedule (str "0 " cron)}],
+     :disabled false})
+
+(defn generate-function-json 
+  [{:keys [fs cloud-name]} cfg]
   (let [tgt (c/tmp-dir!)
-        func-dir (clojure.java.io/file tgt cloud-name)]
+        func-dir (clojure.java.io/file tgt cloud-name)
+        function-json (cond
+                        (= (-> cfg :type) :api)
+                          (function-json-for-api 
+                            (-> cfg :path) 
+                            (if-let [auth (-> cfg :function :authorization)] auth {:authorization :anonymous})) 
+                        (= (-> cfg :type) :timer)
+                          (function-json-for-timer 
+                            (-> cfg :function :cron))
+                        :else
+                          (throw (Exception. (str "Cannot create function.json for unsupported handler type " type))))]
   (doto (clojure.java.io/file func-dir "function.json")
     clojure.java.io/make-parents
-    (serialize-json (function-json path authorization)))
+    (serialize-json function-json))
   (-> fs (c/add-resource tgt) c/commit!)))
 
 
@@ -90,13 +117,24 @@
         (generate-cljs-edn func))
     (assoc conf :fs (-> fs (c/add-source tgt) c/commit!))))
 
-(defn generate-function [fs [path func]]
+(defn generate-function 
+  "Results in index.js and function.json, receiving a function config as declared in hedge.edn."
+  [fs cfg]
   (->
-    (generate-source fs func)
+    (generate-source fs cfg)
     generate-js-func-compile
-    (generate-function-json path func)))
+    (generate-function-json cfg)))
 
-(defn generate-files [{:keys [api]} fs]
-  (if (c/get-env :function-to-build)
-    (reduce generate-function fs (select-keys api [(c/get-env :function-to-build)]))
-    (reduce generate-function fs api)))
+(defn generate-files 
+  "Entry function for generating the output files. Takes hedge.edn as input. Launches generation of one function if :function-to-build is set."
+  [edn-config fs]
+  (if-let [handler (c/get-env :function-to-build)]
+    ;then
+    (generate-function fs (one-handler-config handler edn-config))
+    ;else
+    (do
+      (let [configs (select-keys edn-config SUPPORTED_HANDLERS)
+            handler-configs (-> (for [config-type (keys configs)]
+                                  (map (fn [item] (one-handler-config (first item) edn-config)) (get configs config-type))) 
+                                flatten)]
+        (reduce generate-function fs handler-configs)))))

--- a/boot/src/boot_hedge/common/core.clj
+++ b/boot/src/boot_hedge/common/core.clj
@@ -31,3 +31,25 @@
     (dashed-alphanumeric (namespace handler))
     "__"
     (dashed-alphanumeric (name handler))))
+
+(defn ^:private ->handler
+  "Helper to create handler variables"
+  [key handler value]
+  {key {handler value}})
+
+(defn ^:private handler-config 
+  "Gets handler (given as string) config from hedge.edn, returns a map of type one-handler-config"
+  [handler edn-config]
+  (into {} 
+    (map 
+      (fn [key] (when-let [value (get (-> edn-config key) handler)] 
+                  (->handler key handler value))) 
+      (keys edn-config))))
+
+(defn one-handler-config 
+  "Returns a one-handler-cfg map"
+  [handler edn-config]
+  (let [cfg (handler-config handler edn-config)]
+  {:type (-> cfg keys first)
+   :path handler
+   :function (get (first (vals cfg)) handler)}))

--- a/boot/src/boot_hedge/common/core.clj
+++ b/boot/src/boot_hedge/common/core.clj
@@ -4,6 +4,10 @@
    [clojure.string :as str]
    [cheshire.core :refer [generate-stream]]))
 
+(def SUPPORTED_HANDLERS [:api :timer])
+(def AZURE_FUNCTION {:api 'azure-api-function
+                    :timer 'azure-timer-function})
+
 (defn print-and-return [s]
   (clojure.pprint/pprint s)
   s)

--- a/boot/src/boot_hedge/common/core.clj
+++ b/boot/src/boot_hedge/common/core.clj
@@ -57,3 +57,19 @@
   {:type (-> cfg keys first)
    :path handler
    :function (get (first (vals cfg)) handler)}))
+
+(defn ^:private item->handler-name 
+  "helper to clarify expression, extracting the handler name during calling map function."
+  [item] 
+  (first item))
+
+(defn one-handler-configs
+  "Returns a sequence of one-handler-configs"
+  [edn-config]
+  (let [configs (select-keys edn-config SUPPORTED_HANDLERS)]
+    (-> 
+      (for [config-type (keys configs)]
+      (map 
+        (fn [item] (one-handler-config (item->handler-name item) edn-config)) 
+        (get configs config-type))) 
+      flatten)))

--- a/boot/src/boot_hedge/core.clj
+++ b/boot/src/boot_hedge/core.clj
@@ -2,6 +2,9 @@
   (:require [boot.core          :as c]))
 
 (def SUPPORTED_CLOUDS [:aws :azure])
+(def SUPPORTED_HANDLERS [:api :timer])
+(def AZURE_FUNCTION {:api 'azure-api-function
+                     :timer 'azure-timer-function})
 
 (c/deftask hedge-help
   "WARNING: run this task to get more info" []

--- a/boot/src/boot_hedge/core.clj
+++ b/boot/src/boot_hedge/core.clj
@@ -2,9 +2,6 @@
   (:require [boot.core          :as c]))
 
 (def SUPPORTED_CLOUDS [:aws :azure])
-(def SUPPORTED_HANDLERS [:api :timer])
-(def AZURE_FUNCTION {:api 'azure-api-function
-                     :timer 'azure-timer-function})
 
 (c/deftask hedge-help
   "WARNING: run this task to get more info" []

--- a/boot/test/boot_hedge/common_test.clj
+++ b/boot/test/boot_hedge/common_test.clj
@@ -1,0 +1,48 @@
+(ns boot-hedge.common_test
+  (:require [clojure.test :refer :all]
+            [boot-hedge.common.core :refer :all]))
+
+; note that the class names are prefixed with ', we are testing data structure, not functionality
+(def hedge-edn
+  {:api {"api1" {:handler 'my_cool_function.core/crunch-my-data :authorization :anonymous}
+         "api2" {:handler 'my_cool_function.core/hello :authorization :function}}
+
+   :timer {"timer1" {:handler 'my_cool_function.core/timer-handler :cron "*/10 * * * *"}
+           "timer2" {:handler 'my_cool_function.core/timer-handler-broken :cron "*/10 * * * *"}}
+          
+   :disabled-api {"api2" {:handler 'my_cool_function.core/hello :authorization :anonymous}
+                 "api3" {:handler 'my_cool_function.core/crunch-my-data :authorization :anonymous}}})
+
+(deftest one-handler-config-test
+  (testing "Tests if a one-handler-config can be created with hedge.edn input"
+    (testing "if configs can be handled individually"      
+      
+      (is (= (one-handler-config "api1" hedge-edn) 
+             {:type :api
+              :function {:handler 'my_cool_function.core/crunch-my-data :authorization :anonymous}
+              :path "api1"}))
+              
+      (is (= (one-handler-config "timer2" hedge-edn) 
+             {:type :timer
+              :function {:handler 'my_cool_function.core/timer-handler-broken :cron "*/10 * * * *"}
+              :path "timer2"})))))
+
+(deftest one-handler-configs-test
+  (testing "Tests if a sequence of one-handler-configs can be created with hedge.edn input"
+    (testing "if configs can be handled individually"      
+      (let [configs (one-handler-configs hedge-edn)]
+        (is (= (-> configs count) 
+               4))
+
+        (is (= (-> (filter #(= (-> % :type) :api) configs) count)
+              2))
+
+        (is (= (-> (filter #(= (-> % :type) :timer) configs) count)
+              2))
+
+        (is (zero? (-> (filter #(= (-> % :type) :disabled-api) configs) count)))
+
+        (is (= (-> (filter #(= (-> % :path) "api1") configs) first)
+               {:type :api
+                :function {:handler 'my_cool_function.core/crunch-my-data :authorization :anonymous}
+                :path "api1"}))))))

--- a/boot/test/boot_hedge/function_app_test.clj
+++ b/boot/test/boot_hedge/function_app_test.clj
@@ -2,8 +2,50 @@
     (:require [clojure.test :refer :all]
               [boot-hedge.azure.function-app :refer :all]))
   
+(def api-handler-config1
+  {:type :api
+  :function {:handler 'my_cool_function.core/crunch-my-data :authorization :anonymous}
+  :path "api1"})
+
+(def api-handler-config2
+  {:type :api
+  :function {:handler 'my_cool_function.core/crunch-my-data :authorization :function}
+  :path "api2"})
+
+(def api-handler-config3
+  {:type :api
+  :function {:handler 'my_cool_function.core/crunch-my-data}
+  :path "api3"})
+
+(def timer-handler-config
+ {:type :timer
+  :function {:handler 'my_cool_function.core/timer-handler-broken :cron "*/10 * * * *"}
+  :path "timer2"})
+
 (deftest function-json-test
   (testing "symbol representing the function is normalized to URL compatible form"
     (testing "allows changing path"      
       (is (= (generate-cloud-name (symbol "my-app.core" "fn-name"))
              "my-app_core__fn-name")))))
+
+(deftest function-type->function-json-test
+  (testing "Testing function.json generation for Azure"
+    (testing "Makes an app possible to hook up with Azure serverless runtime"
+      (let [json-api1   (function-type->function-json api-handler-config1)
+            json-api2   (function-type->function-json api-handler-config2)
+            json-api3   (function-type->function-json api-handler-config3)
+            json-timer (function-type->function-json timer-handler-config)]
+        
+        (is (= (-> json-api1 :bindings first :type) "httpTrigger"))
+        (is (= (-> json-api1 :bindings first :route) (-> "api1")))
+        (is (= (-> json-api1 :bindings first :authLevel) "anonymous"))
+
+        (is (= (-> json-api2 :bindings first :route) (-> "api2")))
+        (is (= (-> json-api2 :bindings first :authLevel) "function"))
+     
+        ; if authentication was omitted
+        (is (= (-> json-api3 :bindings first :route) (-> "api3")))
+        (is (= (-> json-api3 :bindings first :authLevel) "anonymous"))
+
+        (is (= (-> json-timer :bindings first :type) "timerTrigger"))
+        (is (= (-> json-timer :bindings first :schedule) "0 */10 * * * *"))))))

--- a/library/src/hedge/azure/function_app.clj
+++ b/library/src/hedge/azure/function_app.clj
@@ -3,5 +3,8 @@
 
 
 
-(defmacro azure-function [f]
-  `(node-module1 (hedge.azure.function-app/azure-function-wrapper ~f)))
+(defmacro azure-api-function [f]
+  `(node-module1 (hedge.azure.function-app/azure-api-function-wrapper ~f)))
+
+(defmacro azure-timer-function [f]
+  `(node-module1 (hedge.azure.function-app/azure-timer-function-wrapper ~f)))

--- a/library/src/hedge/azure/function_app.cljs
+++ b/library/src/hedge/azure/function_app.cljs
@@ -56,6 +56,11 @@
      :body            (get r "body")}))  ; TODO: should use codec or smth probably to handle request body type
   
 
+(defn azure->timer
+  "Converts incoming timer trigger to Hedge timer handler"
+  [timer]
+  (let [timer (js->clj timer)]
+    {:trigger-time (str (get timer "next") \Z)}))   ; Azure times are UTC but timestamps miss TimeZone
 
 (defn ring->azure [context codec]
   (fn [raw-resp]
@@ -64,22 +69,40 @@
       (.done context nil (clj->js {:body raw-resp}))
       (.done context nil (clj->js raw-resp)))))
 
-(defn azure-function-wrapper
+(defn azure-api-function-wrapper
+  "wrapper used for http in / http out api function"
   ([handler]
-   (azure-function-wrapper handler nil))
+   (azure-api-function-wrapper handler nil))
   ([handler codec]
    (fn [context req]
      (try
        (timbre/merge-config! {:appenders {:console nil}})
        (timbre/merge-config! {:appenders {:azure (timbre-appender (.-log context))}})
+       (trace (str "request: " (js->clj req)))
        (let [ok     (ring->azure context codec)
              logfn (.-log context)
              result (handler (into (azure->ring req) {:log logfn}))]
 
-          (trace (str "request: " (js->clj req)))
+          
           (cond
             (satisfies? ReadPort result) (do (info "Result is channel, content pending...")
                                            (go (ok (<! result))))
             (string? result)             (ok {:body result})
             :else                        (ok result)))
        (catch :default e (.done context e nil))))))
+
+(defn azure-timer-function-wrapper
+  "wrapper used for timer-triggered function"
+  ([handler]
+    (azure-timer-function-wrapper handler nil))
+  ([handler codec]
+    (fn [context timer]
+      (try 
+        (timbre/merge-config! {:appenders {:console nil}})
+        (timbre/merge-config! {:appenders {:azure (timbre-appender (.-log context))}})
+        (trace (str "timer: " (js->clj timer)))
+        (let [ok    #(.done context nil)
+              logfn (.-log context)
+              result (handler (into (azure->timer timer) {:log logfn}))]
+          (ok))
+        (catch :default e (.done context e nil))))))

--- a/library/test/hedge/azure/function_app_test.cljs
+++ b/library/test/hedge/azure/function_app_test.cljs
@@ -3,7 +3,7 @@
             [cljs.core.async :refer [chan put!]]
             [goog.object :as gobj]
             [taoensso.timbre :as timbre]
-            [hedge.azure.function-app :refer [azure-function-wrapper azure->ring] :refer-macros [azure-function]]
+            [hedge.azure.function-app :refer [azure-api-function-wrapper azure->ring] :refer-macros [azure-api-function]]
             [hedge.azure.common :refer [azure-context-logger-mock]]))
 
 (def fixture-once
@@ -49,54 +49,54 @@
   [m handler assertions]
   (testing m
     (async done
-      ((azure-function-wrapper handler)
+      ((azure-api-function-wrapper handler)
          (azure-ctx #(do (assertions %) (done)))
          azure-req))))
             
-(deftest azure-function-wrapper-test-calls-done-after
+(deftest azure-api-function-wrapper-test-calls-done-after
   (testing-azure-wrapper "should call context done with the result given by the handler"
     (constantly "result")
     #(is (= {"body" "result"} %))))
 
-(deftest azure-function-wrapper-test-serialization
+(deftest azure-api-function-wrapper-test-serialization
   (testing-azure-wrapper "should serialize the object returned by handler to camel case js object"
     (constantly {:body {:test-data "Data"}})
     #(is (= (get-in % ["body" "test-data"])  ; TODO: not in camelcase yet
             "Data"))))
 
-(deftest azure-function-wrapper-test-headers
+(deftest azure-api-function-wrapper-test-headers
   (testing-azure-wrapper "should not camel case header fields"
     (constantly {:headers {"Content-Type" "application/json+transit"}})
     #(is (= (get-in % ["headers" "Content-Type"])
             "application/json+transit"))))
             
-(deftest azure-function-wrapper-test-deserialization
+(deftest azure-api-function-wrapper-test-deserialization
   (testing "should deserialize the arguments to maps with dashed keywords"
     (async done
-      ((azure-function-wrapper (fn [req] (is (= {:test-data {:some-field "Data"}} req))))
+      ((azure-api-function-wrapper (fn [req] (is (= {:test-data {:some-field "Data"}} req))))
          (azure-ctx #())
          #js {"testData" #js {"someField" "Data"}}))))
 
-(deftest azure-function-wrapper-test-readport
+(deftest azure-api-function-wrapper-test-readport
     (testing "handler returning a core async ReadPort"
       (async done
         (let [results (chan)
-              azure-fn (azure-function-wrapper (constantly results))]
+              azure-fn (azure-api-function-wrapper (constantly results))]
           (testing "should complete on receival of a message"
             (azure-fn azure-ctx #js {:done #(do (is (= "result" %)) (done))})
             (put! results "result"))))))
 
-(deftest azure-function-test
+(deftest azure-api-function-test
   (testing "azure function"
 
     (testing "should have a cli function that returns nil"
-      (azure-function (constantly :result))
+      (azure-api-function (constantly :result))
 
       (is (= (*main-cli-fn*)
              nil)))
     (testing "should export the a wrapped handler"
       (async done
-        (azure-function (fn [req] (is (= {:test-data {:some-field "Data"}} req))))
+        (azure-api-function (fn [req] (is (= {:test-data {:some-field "Data"}} req))))
         ((gobj/get js/module "exports")
           (azure-ctx #())
           #js {"testData" #js {"someField" "Data"}})))))


### PR DESCRIPTION
WIP: 

- azure timers can now be deployed
- unified timestamp with aws
- cron expression can be given in hedge.edn
- library / function app cljs unit tests fixed
- timbre logging for timers
