### PR TITLE
Azure queues implementation

### DIFF
--- a/boot/build.boot
+++ b/boot/build.boot
@@ -12,7 +12,8 @@
                           [com.velisco/clj-ftp "0.3.9"]
                           [adzerk/bootlaces "0.1.13" :scope "test"]
                           [adzerk/boot-test "1.2.0" :scope "test"]
-                          [proto-repl "0.3.1"]])
+                          [proto-repl "0.3.1"]
+                          [org.clojure/core.match "0.3.0-alpha5"]])
 
 (require '[adzerk.bootlaces :refer :all])
 (require '[adzerk.boot-test :refer :all])

--- a/boot/src/boot_hedge/common/core.clj
+++ b/boot/src/boot_hedge/common/core.clj
@@ -5,9 +5,10 @@
    [clojure.string :as str]
    [cheshire.core :refer [generate-stream]]))
 
-(def SUPPORTED_HANDLERS [:api :timer])
+(def SUPPORTED_HANDLERS [:api :timer :queue])
 (def AZURE_FUNCTION {:api 'azure-api-function
-                     :timer 'azure-timer-function})
+                     :timer 'azure-timer-function
+                     :queue 'azure-queue-function})
 (def AWS_FUNCTIONS {:api 'lambda-apigw-function
                     :timer 'lambda-timer-function})
 

--- a/boot/test/boot_hedge/common_test.clj
+++ b/boot/test/boot_hedge/common_test.clj
@@ -4,7 +4,10 @@
 
 ; note that the class names are prefixed with ', we are testing data structure, not functionality
 (def hedge-edn
-  {:api {"api1" {:handler 'my_cool_function.core/crunch-my-data :authorization :anonymous}
+  {:queue {"queue1" {:handler 'mycoolqueuehandler :queue "queue1" :connection "connection-string1"}
+           "queue2" {:handler 'mycoolqueuehandler :queue "queue2" :connection "connection-string2"}}
+    
+   :api {"api1" {:handler 'my_cool_function.core/crunch-my-data :authorization :anonymous}
          "api2" {:handler 'my_cool_function.core/hello :authorization :function}}
 
    :timer {"timer1" {:handler 'my_cool_function.core/timer-handler :cron "*/10 * * * *"}
@@ -25,19 +28,26 @@
       (is (= (one-handler-config "timer2" hedge-edn) 
              {:type :timer
               :function {:handler 'my_cool_function.core/timer-handler-broken :cron "*/10 * * * *"}
-              :path "timer2"})))))
+              :path "timer2"}))
+      (is (= (one-handler-config "queue1" hedge-edn) 
+            {:type :queue
+              :function {:handler 'mycoolqueuehandler :queue "queue1" :connection "connection-string1"}
+              :path "queue1"})))))
 
 (deftest one-handler-configs-test
   (testing "Tests if a sequence of one-handler-configs can be created with hedge.edn input"
     (testing "if configs can be handled individually"      
       (let [configs (one-handler-configs hedge-edn)]
         (is (= (-> configs count) 
-               4))
+               6))
 
         (is (= (-> (filter #(= (-> % :type) :api) configs) count)
               2))
 
         (is (= (-> (filter #(= (-> % :type) :timer) configs) count)
+              2))
+
+        (is (= (-> (filter #(= (-> % :type) :queue) configs) count)
               2))
 
         (is (zero? (-> (filter #(= (-> % :type) :disabled-api) configs) count)))

--- a/boot/test/boot_hedge/function_app_test.clj
+++ b/boot/test/boot_hedge/function_app_test.clj
@@ -22,6 +22,30 @@
   :function {:handler 'my_cool_function.core/timer-handler-broken :cron "*/10 * * * *"}
   :path "timer2"})
 
+(def queue-handler-config 
+  {:type :queue
+  :function {:handler 'my_cool_function.core/queuehandler
+             :queue "myqueue"
+             :connection "AzureWebJobsDashboard"}
+  :path "queue1"})
+
+(def topic-queue-handler-config 
+  {:type :queue
+  :function {:handler 'my_cool_function.core/queuehandler
+             :queue "mytopic"
+             :subscription "subscription"
+             :accessRights "Manage"
+             :connection "AzureWebJobsDashboard"}
+  :path "queue1"})
+
+(def sb-queue-handler-config 
+  {:type :queue
+  :function {:handler 'my_cool_function.core/queuehandler
+              :queue "myqueue"
+              :accessRights "Manage"
+              :connection "AzureWebJobsDashboard"}
+  :path "queue1"})
+
 (deftest function-json-test
   (testing "symbol representing the function is normalized to URL compatible form"
     (testing "allows changing path"      
@@ -31,10 +55,13 @@
 (deftest function-type->function-json-test
   (testing "Testing function.json generation for Azure"
     (testing "Makes an app possible to hook up with Azure serverless runtime"
-      (let [json-api1   (function-type->function-json api-handler-config1)
-            json-api2   (function-type->function-json api-handler-config2)
-            json-api3   (function-type->function-json api-handler-config3)
-            json-timer (function-type->function-json timer-handler-config)]
+      (let [json-api1    (function-type->function-json api-handler-config1)
+            json-api2    (function-type->function-json api-handler-config2)
+            json-api3    (function-type->function-json api-handler-config3)
+            json-timer   (function-type->function-json timer-handler-config)
+            json-queue   (function-type->function-json queue-handler-config)
+            json-topic   (function-type->function-json topic-queue-handler-config)
+            json-sbqueue (function-type->function-json sb-queue-handler-config)]
         
         (is (= (-> json-api1 :bindings first :type) "httpTrigger"))
         (is (= (-> json-api1 :bindings first :route) (-> "api1")))
@@ -48,4 +75,17 @@
         (is (= (-> json-api3 :bindings first :authLevel) "anonymous"))
 
         (is (= (-> json-timer :bindings first :type) "timerTrigger"))
-        (is (= (-> json-timer :bindings first :schedule) "0 */10 * * * *"))))))
+        (is (= (-> json-timer :bindings first :schedule) "0 */10 * * * *"))
+        
+        (is (= (-> json-queue :bindings first :type) "queueTrigger"))
+        (is (= (-> json-queue :bindings first :queueName) "myqueue"))
+
+        (is (= (-> json-topic :bindings first :type) "serviceBusTrigger"))
+        (is (= (-> json-topic :bindings first :topicName) "mytopic"))
+        (is (-> json-topic :bindings first :accessRights))
+        (is (-> json-topic :bindings first :subscriptionName))
+
+        (is (= (-> json-sbqueue :bindings first :type) "serviceBusTrigger"))
+        (is (= (-> json-sbqueue :bindings first :queueName) "myqueue"))
+        (is (-> json-sbqueue :bindings first :accessRights))
+        (is (nil? (-> json-sbqueue :bindings first :subscriptionName)))))))

--- a/library/src/hedge/azure/function_app.clj
+++ b/library/src/hedge/azure/function_app.clj
@@ -8,3 +8,6 @@
 
 (defmacro azure-timer-function [f]
   `(node-module1 (hedge.azure.function-app/azure-timer-function-wrapper ~f)))
+
+(defmacro azure-queue-function [f]
+  `(node-module1 (hedge.azure.function-app/azure-queue-function-wrapper ~f)))


### PR DESCRIPTION
- it is now possible to deploy Queue triggered functions in Azure
- It is possible to deploy Azure Storage Queue, ServiceBus Queue and ServiceBus Topic Queues that use the same handler abstraction
- documentation on how to use it

TODO:
- some modification on which implementation will be used will probably be done when **cloud-config.edn** is implemented