### PR TITLE
Fixes #94. Removed obsolete tests and assertions, fixed async blocks in tests.

### DIFF
--- a/library/src/hedge/azure/function_app.cljs
+++ b/library/src/hedge/azure/function_app.cljs
@@ -125,7 +125,6 @@
   (fn [raw-resp]
     (trace (str "result: " raw-resp))
     (outputs->bindings context outputs) ; persist outputs
-    (trace (str "result: " raw-resp))
     (.done context nil (clj->js raw-resp))))
 
 (defn azure-api-function-wrapper


### PR DESCRIPTION
also: removed duplicate logging

Unit tests of library again show test amounts report and are able to fail.

